### PR TITLE
Fix import paths and directories

### DIFF
--- a/Bates/train_stage2.py
+++ b/Bates/train_stage2.py
@@ -11,16 +11,18 @@ import sys
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
+from pathlib import Path
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(project_root)
+# Repository root for ``common`` imports
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root))
 
 from common.networks_stage2 import get_stage2_network
 from common.loss_functions  import stage2_mse_with_prior_reg
 
-DATA_PATH       = r"C:\Users\david\BathUni\MA50290_24\model_calibration\data\synthetic_data2\Bates\grouped_stage2_bates.npz"
-CHECKPOINT_DIR  = os.path.join(os.path.dirname(__file__), "checkpoints")
-SAVE_PATH       = os.path.join(CHECKPOINT_DIR, "stage2_bates_model.pth")
+DATA_PATH      = project_root / "data" / "synthetic_data2" / "Bates" / "grouped_stage2_bates.npz"
+CHECKPOINT_DIR = Path(__file__).resolve().parent / "checkpoints"
+SAVE_PATH      = CHECKPOINT_DIR / "stage2_bates_model.pth"
 
 BATCH_SIZE      = 32
 EPOCHS          = 100

--- a/GBM/train_stage2.py
+++ b/GBM/train_stage2.py
@@ -11,18 +11,20 @@ import sys
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
+from pathlib import Path
 
 # --- Project root on PYTHONPATH so we can import common ---
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(project_root)
+# Resolve repository root so ``common`` can be imported
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root))
 
 from common.networks_stage2   import get_stage2_network
 from common.loss_functions    import stage2_mse_with_prior_reg
 
 # --- Config ---
-DATA_PATH       = r"C:\Users\david\BathUni\MA50290_24\model_calibration\data\synthetic_data2\GBM\grouped_stage2_gbm.npz"
-CHECKPOINT_DIR  = os.path.join(os.path.dirname(__file__), "checkpoints")
-SAVE_PATH       = os.path.join(CHECKPOINT_DIR, "stage2_gbm_model.pth")
+DATA_PATH      = project_root / "data" / "synthetic_data2" / "GBM" / "grouped_stage2_gbm.npz"
+CHECKPOINT_DIR = Path(__file__).resolve().parent / "checkpoints"
+SAVE_PATH      = CHECKPOINT_DIR / "stage2_gbm_model.pth"
 
 BATCH_SIZE      = 32
 EPOCHS          = 100

--- a/Heston/train_stage2.py
+++ b/Heston/train_stage2.py
@@ -11,16 +11,18 @@ import sys
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
+from pathlib import Path
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(project_root)
+# Repository root for ``common`` imports
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root))
 
 from common.networks_stage2 import get_stage2_network
 from common.loss_functions  import stage2_mse_with_prior_reg
 
-DATA_PATH       = r"C:\Users\david\BathUni\MA50290_24\model_calibration\data\synthetic_data2\Heston\grouped_stage2_heston.npz"
-CHECKPOINT_DIR  = os.path.join(os.path.dirname(__file__), "checkpoints")
-SAVE_PATH       = os.path.join(CHECKPOINT_DIR, "stage2_heston_model.pth")
+DATA_PATH      = project_root / "data" / "synthetic_data2" / "Heston" / "grouped_stage2_heston.npz"
+CHECKPOINT_DIR = Path(__file__).resolve().parent / "checkpoints"
+SAVE_PATH      = CHECKPOINT_DIR / "stage2_heston_model.pth"
 
 BATCH_SIZE      = 32
 EPOCHS          = 100

--- a/MJD/train_stage2.py
+++ b/MJD/train_stage2.py
@@ -11,18 +11,20 @@ import sys
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
+from pathlib import Path
 
 # --- Project root on PYTHONPATH so we can import common ---
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(project_root)
+# Repository root for ``common`` imports
+project_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(project_root))
 
 from common.networks_stage2 import get_stage2_network
 from common.loss_functions  import stage2_mse_with_prior_reg
 
 # --- Config ---
-DATA_PATH       = r"C:\Users\david\BathUni\MA50290_24\model_calibration\data\synthetic_data2\MJD\grouped_stage2_mjd.npz"
-CHECKPOINT_DIR  = os.path.join(os.path.dirname(__file__), "checkpoints")
-SAVE_PATH       = os.path.join(CHECKPOINT_DIR, "stage2_mjd_model.pth")
+DATA_PATH      = project_root / "data" / "synthetic_data2" / "MJD" / "grouped_stage2_mjd.npz"
+CHECKPOINT_DIR = Path(__file__).resolve().parent / "checkpoints"
+SAVE_PATH      = CHECKPOINT_DIR / "stage2_mjd_model.pth"
 
 BATCH_SIZE      = 32
 EPOCHS          = 100

--- a/data/synthetic_data2_generation/Bates/adding_priors.py
+++ b/data/synthetic_data2_generation/Bates/adding_priors.py
@@ -12,7 +12,8 @@ import torch
 from collections import defaultdict
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[1]
+# Add repository root to the path so ``common`` can be imported
+project_root = Path(__file__).resolve().parents[3]
 sys.path.append(str(project_root))
 
 from common import get_stage1_network

--- a/data/synthetic_data2_generation/GBM/adding_priors.py
+++ b/data/synthetic_data2_generation/GBM/adding_priors.py
@@ -12,8 +12,9 @@ import torch
 from collections import defaultdict
 from pathlib import Path
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(project_root)
+# Resolve project root (repo root) so we can import the ``common`` package
+project_root = Path(__file__).resolve().parents[3]
+sys.path.append(str(project_root))
 
 from common import get_stage1_network
 

--- a/data/synthetic_data2_generation/Heston/adding_priors.py
+++ b/data/synthetic_data2_generation/Heston/adding_priors.py
@@ -12,7 +12,8 @@ import torch
 from collections import defaultdict
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[1]
+# Resolve repo root to make ``common`` importable
+project_root = Path(__file__).resolve().parents[3]
 sys.path.append(str(project_root))
 
 from common import get_stage1_network

--- a/data/synthetic_data2_generation/MJD/adding_priors.py
+++ b/data/synthetic_data2_generation/MJD/adding_priors.py
@@ -12,8 +12,8 @@ import torch
 from collections import defaultdict
 from pathlib import Path
 
-# Add project root for imports
-project_root = Path(__file__).resolve().parents[1]
+# Add repository root for imports
+project_root = Path(__file__).resolve().parents[3]
 sys.path.append(str(project_root))
 
 from common import get_stage1_network


### PR DESCRIPTION
## Summary
- point adding_priors scripts to repo root for importing `common`
- use repo-relative paths in all `train_stage2.py` scripts

## Testing
- `python -m py_compile Bates/train_stage2.py GBM/train_stage2.py Heston/train_stage2.py MJD/train_stage2.py data/synthetic_data2_generation/Bates/adding_priors.py data/synthetic_data2_generation/GBM/adding_priors.py data/synthetic_data2_generation/Heston/adding_priors.py data/synthetic_data2_generation/MJD/adding_priors.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b9f4dc788332835fc92c5f7a7dca